### PR TITLE
Eps update

### DIFF
--- a/src/Core/Resources/Material.cpp
+++ b/src/Core/Resources/Material.cpp
@@ -114,7 +114,7 @@ mat_rsrc_ptr Material::extract(const CompMapPtr remove_comp, double remove_amt, 
        << " of a something from a material that has " 
        << original_amt << " of something." << endl;
     throw CycNegativeValueException(ss.str());
-  } else if (final_amt <= 0) {final_amt = 0;}
+  } else if (final_amt <= cyclus::eps_rsrc()) {final_amt = 0;}
 
   int iso;
   double remove_amt_i, final_amt_i;

--- a/src/Core/Resources/Material.cpp
+++ b/src/Core/Resources/Material.cpp
@@ -72,7 +72,9 @@ void Material::absorb(mat_rsrc_ptr matToAdd) {
 
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 mat_rsrc_ptr Material::extract(double mass) {
-  if(quantity_ < mass){
+  if (mass < 0) {
+    throw CycNegativeValueException("Can't remove a negative amoutn of material");
+  } else if(quantity_ < mass){
     string err = "The mass ";
     err += mass;
     err += " cannot be extracted from Material with ID ";
@@ -96,6 +98,9 @@ mat_rsrc_ptr Material::extract(double mass) {
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 mat_rsrc_ptr Material::extract(const CompMapPtr remove_comp, double remove_amt, MassUnit unit) {
   
+  if (remove_amt < 0) 
+    throw CycNegativeValueException("Can't remove a negative amoutn of material");
+
   CompMapPtr final_comp = CompMapPtr(this->unnormalizeComp(MASS));
   remove_comp->massify();
   assert(!final_comp->normalized());

--- a/src/Testing/MaterialTests.cpp
+++ b/src/Testing/MaterialTests.cpp
@@ -224,6 +224,12 @@ TEST_F(MaterialTest, ExtractMass) {
 }
 
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -    
+TEST_F(MaterialTest, ExtractNegMass) {
+  mat_rsrc_ptr m;
+  EXPECT_THROW(m = test_mat_->extract(-1),CycNegativeValueException); 
+}
+
+//- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -    
 TEST_F(MaterialTest, Extract_complete) {
 
   // Complete extraction
@@ -232,6 +238,13 @@ TEST_F(MaterialTest, Extract_complete) {
   EXPECT_TRUE( m1->isoVector().compEquals(test_comp_));
   EXPECT_FLOAT_EQ( 0, test_mat_->quantity() );
   EXPECT_FLOAT_EQ( test_size_, m1->quantity() );
+}
+
+//- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -    
+TEST_F(MaterialTest, ExtractNegComp) {
+  mat_rsrc_ptr m;
+  EXPECT_THROW(m = test_mat_->extract(test_comp_,-1),
+               CycNegativeValueException);
 }
 
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -    


### PR DESCRIPTION
Added a check for negative extrusion amounts and tests. Added a check for the final_amt to compare against cyclus::eps vs. 0. Feel free to cherry pick only the first commit if you disagree with this.
